### PR TITLE
BACKSNS-951: Force http1.1 in webapp nginx

### DIFF
--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -14,6 +14,8 @@ server {
     listen       8080;
     listen  [::]:8080;
     server_name  localhost;
+    
+    proxy_http_version 1.1;
 
     add_header Content-Security-Policy "script-src * 'unsafe-inline'; worker-src 'self' blob:;";
 


### PR DESCRIPTION
to work properly with Istio service mesh for having mTLS with Temporal